### PR TITLE
add query_selector doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ A handful of facades:
 - create [shadow dom](./docs/wc.md) and manage form values
 - listen to [events](./docs/events.md)
 - [subscribe](./docs/subscription.md) to external data stores
-- push actions like "renders" to the [micro task](./docs/microtask.md) queue
+- push renders to the [microtask](./docs/microtask.md) queue
 - [bind](./docs/bind.md) functions to elements
+- [query](./docs/query_selector.md) the shadow dom
 
 ## Examples
 

--- a/dist/microtask.d.ts
+++ b/dist/microtask.d.ts
@@ -1,13 +1,13 @@
-interface MicrotaskParamsInterface<E> {
-    host: E;
+interface MicrotaskParamsInterface {
+    host: Object;
     callbacks: Function[];
 }
 interface MicrotaskInterface {
     queue(): void;
 }
-declare class Microtask<E extends Object> implements MicrotaskInterface {
+declare class Microtask implements MicrotaskInterface {
     #private;
-    constructor(params: MicrotaskParamsInterface<E>);
+    constructor(params: MicrotaskParamsInterface);
     queue(): void;
 }
 export type { MicrotaskInterface };

--- a/docs/bind.md
+++ b/docs/bind.md
@@ -14,7 +14,10 @@ Add a list of callbacks on instantiation.
 import { Bind } from "wctk";
 
 class MyElement extends HTMLElement {
-	#bc = new Bind(this, [this.elementCallback];
+	#bc = new Bind({
+		host: this,
+		callbacks: [this.elementCallback],
+	};
 
 	elementCallback(e: KeyboardEvent) {
 		// This function can be passed as a callback to event listeners now!

--- a/docs/microtask.md
+++ b/docs/microtask.md
@@ -16,7 +16,10 @@ import { Microtask } from "wctk";
 class MyElement extends HTMLElement {
 	static observedAttributes = ["width"];
 
-	#rc = new Microtask(this, [this.#render]);
+	#rc = new Microtask({
+		host: this,
+		callbacks: [this.#render],
+	});
 
 	#render() {
 		// update DOM here!

--- a/docs/query_selector.md
+++ b/docs/query_selector.md
@@ -1,0 +1,40 @@
+# QuerySelector Controller
+
+Create a map of selector queries.
+
+## How to use
+
+Add a `QuerySelector` controller to a web component.
+
+Add a list of callbacks on instantiation.
+
+```html
+<my-element>
+	<template shadowrootmode="closed">
+		<span greeting>UwU</span>
+	</template>
+</my-element>
+```
+
+```ts
+import { QuerySelector } from "wctk";
+
+class MyElement extends HTMLElement {
+	#wc = new Wc({ host: this });
+	#qc = new QuerySelector({
+		host: this.#wc.shadowRoot,
+		selectors: [["hello_world", "[greeting]"]],
+	});
+
+	doSomething() {
+		// first occurance
+		let helloWorld = this.#qc.get("hello_world");
+
+		// NodeList
+		let allTheHelloWorlds = this.#qc.getAll("hello_world");
+
+		// update queries
+		this.#qc.query();
+	}
+}
+```

--- a/examples/stopwatch/stopwatch.js
+++ b/examples/stopwatch/stopwatch.js
@@ -5,11 +5,11 @@ import { Bind, Wc, Microtask } from "wctk";
 	on the microtask queue.
 */
 class Stopwatch extends HTMLElement {
-	#bc = new Bind({ host: this, callbacks: [this.update] });
 	#wc = new Wc({ host: this });
-	#state = getStateFromShadowDOM(this.#wc.shadowRoot);
-
 	#rc = new Microtask({ host: this, callbacks: [this.#render] });
+	#bc = new Bind({ host: this, callbacks: [this.update] });
+
+	#state = getStateFromShadowDOM(this.#wc.shadowRoot);
 
 	#render() {
 		this.#state.el.textContent = this.#state.count.toFixed(2);

--- a/src/microtask.ts
+++ b/src/microtask.ts
@@ -1,5 +1,5 @@
-interface MicrotaskParamsInterface<E> {
-	host: E;
+interface MicrotaskParamsInterface {
+	host: Object;
 	callbacks: Function[];
 }
 
@@ -7,11 +7,11 @@ interface MicrotaskInterface {
 	queue(): void;
 }
 
-class Microtask<E extends Object> implements MicrotaskInterface {
+class Microtask implements MicrotaskInterface {
 	#queued = false;
 	#callbacks: Function[];
 
-	constructor(params: MicrotaskParamsInterface<E>) {
+	constructor(params: MicrotaskParamsInterface) {
 		// this.queue = this.queue.bind(this);
 		this.#callbacks = getBoundCallbacks(params);
 	}
@@ -29,9 +29,7 @@ class Microtask<E extends Object> implements MicrotaskInterface {
 	}
 }
 
-function getBoundCallbacks<E extends Object>(
-	params: MicrotaskParamsInterface<E>,
-): Function[] {
+function getBoundCallbacks(params: MicrotaskParamsInterface): Function[] {
 	let { host, callbacks } = params;
 
 	let boundCallbacks: Function[] = [];


### PR DESCRIPTION
- add query selector doc
- stop watch example looks nicer, better ordering of controllers
- update other docs to include new params objects
- remove generics in microtask controller